### PR TITLE
fix: patch Generator to require yeoman-generator/lib/actions/install

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,5 +1,9 @@
 "use strict";
 const Generator = require("yeoman-generator");
+// patches the Generator for the install tasks as new custom install
+// tasks produce ugly errors! (Related issue: https://github.com/yeoman/environment/issues/309)
+require('lodash').extend(Generator.prototype, require('yeoman-generator/lib/actions/install'))
+
 const chalk = require("chalk");
 const yosay = require("yosay");
 const path = require("path");


### PR DESCRIPTION
Avoids an installation problem, as done in the other TS templates we have so far.

Fixes https://github.com/ui5-community/generator-ui5-ts-library/issues/4