### PR TITLE
Use MetadataOptions type, update ts-interface-generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -26,6 +26,10 @@ module.exports = class extends Generator {
             return `@${framework.toLowerCase()}/${typesName}`;
         };
 
+        const isMetadataOptionsAvailable = function(version) {
+            return semver.gte(version, "1.110.0");
+        };
+
         // Have Yeoman greet the user.
         if (!this.options.embedded) {
             this.log(
@@ -120,6 +124,11 @@ module.exports = class extends Generator {
             // determine the ts-types and version
             this.config.set("tstypes", getTypePackageFor(props.framework, props.frameworkVersion));
             this.config.set("tstypesVersion", props.frameworkVersion);
+
+            // determine how the metadata object can be typed
+            const metadataOptionsAvailable = isMetadataOptionsAvailable(props.frameworkVersion);
+            this.config.set("metadataOptionsImportLine", metadataOptionsAvailable ? 'import type { MetadataOptions } from "sap/ui/core/Element";\n' : "");
+            this.config.set("metadataOptionsType", metadataOptionsAvailable ? "MetadataOptions" : "object");
 
             this.config.set("namespaceURI", props.namespace.split(".").join("/"));
             this.config.set(

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -11,7 +11,7 @@
       "@typescript-eslint/eslint-plugin": "^5.17.0",
       "@typescript-eslint/parser": "^5.17.0",
       "@ui5/cli": "^2.14.7",
-      "@ui5/ts-interface-generator": "^0.5.0",
+      "@ui5/ts-interface-generator": "^0.6.2",
       "babel-preset-transform-ui5": "^7.0.5",
       "eslint": "^8.12.0",
       "karma": "^6.3.17",

--- a/generators/app/templates/src/baselibrary/Example.gen.d.ts
+++ b/generators/app/templates/src/baselibrary/Example.gen.d.ts
@@ -2,32 +2,134 @@ import { ExampleColor } from "./library";
 import Event from "sap/ui/base/Event";
 import { PropertyBindingInfo } from "sap/ui/base/ManagedObject";
 import { $ControlSettings } from "sap/ui/core/Control";
-
+<%= metadataOptionsImportLine %>
 declare module "./Example" {
 
     /**
      * Interface defining the settings object used in constructor calls
      */
     interface $ExampleSettings extends $ControlSettings {
+
+        /**
+         * The text to display.
+         */
         text?: string | PropertyBindingInfo;
+
+        /**
+         * The color to use (default to "Default" color).
+         */
         color?: ExampleColor | PropertyBindingInfo | `{${string}}`;
+
+        /**
+         * Event is fired when the user clicks the control.
+         */
         press?: (event: Event) => void;
     }
 
     export default interface Example {
 
         // property: text
+
+        /**
+         * Gets current value of property "text".
+         *
+         * The text to display.
+         *
+         * @returns Value of property "text"
+         */
         getText(): string;
+
+        /**
+         * Sets a new value for property "text".
+         *
+         * The text to display.
+         *
+         * When called with a value of "null" or "undefined", the default value of the property will be restored.
+         *
+         * @param text New value for property "text"
+         * @returns Reference to "this" in order to allow method chaining
+         */
         setText(text: string): this;
 
         // property: color
+
+        /**
+         * Gets current value of property "color".
+         *
+         * The color to use (default to "Default" color).
+         *
+         * Default value is: "ExampleColor.Default"
+         * @returns Value of property "color"
+         */
         getColor(): ExampleColor;
+
+        /**
+         * Sets a new value for property "color".
+         *
+         * The color to use (default to "Default" color).
+         *
+         * When called with a value of "null" or "undefined", the default value of the property will be restored.
+         *
+         * Default value is: "ExampleColor.Default"
+         * @param [color="ExampleColor.Default"] New value for property "color"
+         * @returns Reference to "this" in order to allow method chaining
+         */
         setColor(color: ExampleColor): this;
 
         // event: press
+
+        /**
+         * Attaches event handler "fn" to the "press" event of this "Example".
+         *
+         * Event is fired when the user clicks the control.
+         *
+         * When called, the context of the event handler (its "this") will be bound to "oListener" if specified,
+         * otherwise it will be bound to this "Example" itself.
+         *
+         * @param fn The function to be called when the event occurs
+         * @param listener Context object to call the event handler with. Defaults to this "Example" itself
+         *
+         * @returns Reference to "this" in order to allow method chaining
+         */
         attachPress(fn: (event: Event) => void, listener?: object): this;
+
+        /**
+         * Attaches event handler "fn" to the "press" event of this "Example".
+         *
+         * Event is fired when the user clicks the control.
+         *
+         * When called, the context of the event handler (its "this") will be bound to "oListener" if specified,
+         * otherwise it will be bound to this "Example" itself.
+         *
+         * @param data An application-specific payload object that will be passed to the event handler along with the event object when firing the event
+         * @param fn The function to be called when the event occurs
+         * @param listener Context object to call the event handler with. Defaults to this "Example" itself
+         *
+         * @returns Reference to "this" in order to allow method chaining
+         */
         attachPress<CustomDataType extends object>(data: CustomDataType, fn: (event: Event, data: CustomDataType) => void, listener?: object): this;
+
+        /**
+         * Detaches event handler "fn" from the "press" event of this "Example".
+         *
+         * Event is fired when the user clicks the control.
+         *
+         * The passed function and listener object must match the ones used for event registration.
+         *
+         * @param fn The function to be called, when the event occurs
+         * @param listener Context object on which the given function had to be called
+         * @returns Reference to "this" in order to allow method chaining
+         */
         detachPress(fn: (event: Event) => void, listener?: object): this;
+
+        /**
+         * Fires event "press" to attached listeners.
+         *
+         * Event is fired when the user clicks the control.
+         *
+         * @param parameters Parameters to pass along with the event
+         * @returns Reference to "this" in order to allow method chaining
+         */
         firePress(parameters?: object): this;
     }
 }

--- a/generators/app/templates/src/baselibrary/Example.ts
+++ b/generators/app/templates/src/baselibrary/Example.ts
@@ -4,9 +4,8 @@
 
 // Provides control <%= librarynamespace %>.Example.
 import Control from	"sap/ui/core/Control";
-import ExampleRenderer from "./ExampleRenderer";
+<%- metadataOptionsImportLine %>import ExampleRenderer from "./ExampleRenderer";
 import { ExampleColor } from "./library";
-
 
 
 /**
@@ -29,7 +28,7 @@ export default class Example extends Control {
 	constructor(id?: string, settings?: $ExampleSettings);
 	constructor(id?: string, settings?: $ExampleSettings) { super(id, settings); }
 
-	static readonly metadata = {
+	static readonly metadata: <%= metadataOptionsType %> = {
 		library: "<%= librarynamespace %>",
 		properties: {
 			/**


### PR DESCRIPTION
- Since 1.110.0, the "MetadataOptions" type allows full typing of the control metadata. Also, specifying this type - or just "object" below 1.110.0 - enables inheriting from such controls (cf. https://github.com/SAP/ui5-typescript/issues/338). Both is done by this change.

- ts-interface-generator has been extended with JSDoc generation; update to this version.

- Also .gitignore any content in the "test" folder (which houses generated trial projects)