### PR TITLE
fix: upgrade @ui5/ts-interface-generator to v0.8.0

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -26,7 +26,7 @@
 		"@typescript-eslint/eslint-plugin": "^6.2.0",
 		"@typescript-eslint/parser": "^6.2.0",
 		"@ui5/cli": "^3.3.4",
-		"@ui5/ts-interface-generator": "^0.7.0",
+		"@ui5/ts-interface-generator": "^0.8.0",
 		"eslint": "^8.46.0",
 		"karma": "^6.4.2",
 		"karma-chrome-launcher": "^3.2.0",


### PR DESCRIPTION
Solves peer dependency conflict in ui5-tooling-transpile which requires a version >=0.8.0.