### PR TITLE
feat: add ui5 middleware code coverage

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -26,6 +26,7 @@
 		"@typescript-eslint/eslint-plugin": "^6.7.4",
 		"@typescript-eslint/parser": "^6.7.4",
 		"@ui5/cli": "^3.6.1",
+		"@ui5/middleware-code-coverage": "^1.1.0",
 		"@ui5/ts-interface-generator": "^0.8.1",
 		"eslint": "^8.50.0",
 		"karma": "^6.4.2",

--- a/generators/app/templates/test/_library_/qunit/testsuite.qunit.ts
+++ b/generators/app/templates/test/_library_/qunit/testsuite.qunit.ts
@@ -17,7 +17,11 @@ export default {
 			qunitBridge: true,
 			useFakeTimers: false
 		},
-		module: "./{name}.qunit"
+		module: "./{name}.qunit",
+		coverage: {
+			only: ["<%= libURI %>"],
+			never: ["test-resources/<%= libURI %>"]
+		}
 	},
 	tests: {
 		// test file for the Example control

--- a/generators/app/templates/ui5.yaml
+++ b/generators/app/templates/ui5.yaml
@@ -18,3 +18,5 @@ server:
       afterMiddleware: compression
     - name: ui5-middleware-livereload
       afterMiddleware: compression
+    - name: "@ui5/middleware-code-coverage"
+      afterMiddleware: compression


### PR DESCRIPTION
Allows client side code coverage generation for ES6+ code powered by https://github.com/SAP/ui5-tooling-extensions/tree/main/packages/middleware-code-coverage.

JIRA: CPOUI5FOUNDATION-721
