### PR TITLE
fix: update test suite best practices

### DIFF
--- a/generators/app/templates/test/_library_/qunit/testsuite.qunit.ts
+++ b/generators/app/templates/test/_library_/qunit/testsuite.qunit.ts
@@ -1,12 +1,9 @@
 export default {
 	name: "QUnit TestSuite for <%= libId %>",
 	defaults: {
-		bootCore: true,
 		ui5: {
-			libs: "sap.ui.core,<%= libId %>",
-			theme: "<%= defaultTheme %>",
-			noConflict: true,
-			preload: "auto"
+			libs: ["sap.ui.core", "<%= libId %>"],
+			theme: "<%= defaultTheme %>"
 		},
 		qunit: {
 			version: 2,
@@ -16,8 +13,7 @@ export default {
 			version: 4,
 			qunitBridge: true,
 			useFakeTimers: false
-		},
-		module: "./{name}.qunit"
+		}
 	},
 	tests: {
 		// test file for the Example control


### PR DESCRIPTION
- Remove configuration of deprecated options (preload, bootCore)
- Remove configuration that matches test starter defaults (noConflict, module)
- Convert ui5 libs to array